### PR TITLE
refactor: avoid prisma instance creation on either development or test

### DIFF
--- a/src/services/database/index.ts
+++ b/src/services/database/index.ts
@@ -1,3 +1,9 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from '@prisma/client'
 
-export const prisma = new PrismaClient()
+const globalForPrisma = global as { prisma?: PrismaClient }
+
+export const prisma = globalForPrisma.prisma || new PrismaClient()
+
+if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
+  globalForPrisma.prisma = prisma
+}


### PR DESCRIPTION
On development a prisma instance is create when the server is restarted. A new prisma instance is not to be created if the environment is either "development" or "test".
